### PR TITLE
Fix NULL ptr scrolling menu suboptions

### DIFF
--- a/scenes/blackhat_scene_start.c
+++ b/scenes/blackhat_scene_start.c
@@ -61,6 +61,8 @@ static void blackhat_scene_start_var_list_change_callback(VariableItem* item)
     BlackhatApp* app = variable_item_get_context(item);
     furi_assert(app);
 
+    app->selected_menu_index = variable_item_list_get_selected_item_index(app->var_item_list);
+
     const BlackhatItem* menu_item = &items[app->selected_menu_index];
 
     uint8_t item_index = variable_item_get_current_value_index(item);


### PR DESCRIPTION
noticed that scrolling list networks: wlan0 crashed with a null pointer dereference, turns out `selected_menu_index` was only set when clicking the item; looks like this code is based on the marauder app atleast loosely, that one has a tick event handler that updates `selected_menu_index` every few hundred milliseconds, feel like this approach updating it in the change handler before using it makes more sense